### PR TITLE
Block traffic with ebtables instead of bringing interface down

### DIFF
--- a/phaul/util.py
+++ b/phaul/util.py
@@ -59,6 +59,18 @@ def ifdown(ifname):
 	os.system("ip link set %s down" % ifname)
 
 
+def lock_veth(nfchain, veth):
+	ebtables_modify("-I ip-filter-%s -j %s" % (veth, nfchain))
+
+
+def unlock_veth(nfchain, veth):
+	ebtables_modify("-D ip-filter-%s -j %s" % (veth, nfchain))
+
+
+def ebtables_modify(command):
+	os.system("ebtables %s" % command)
+
+
 def bridge_add(ifname, brname):
 	logging.info("\t\tAdd %s to %s", ifname, brname)
 	os.system("brctl addif %s %s" % (brname, ifname))


### PR DESCRIPTION
p.haul locks network traffic for veth interfaces by bringing them
down. This behavior does not allow p.haul to obtain data from NFS
server for NFS-client migration case. Replacing ifdown with
ebtables rules is a first step to enable such migration.

Signed-off-by: Pavel Vokhmyanin <pvokhmyanin@virtuozzo.com>