### PR TITLE
Drop ifdown from net_lock

### DIFF
--- a/phaul/p_haul_vz.py
+++ b/phaul/p_haul_vz.py
@@ -359,14 +359,10 @@ class p_haul_type(object):
 		pass
 
 	def net_lock(self):
-		for veth in self._veths:
-			util.ifdown(veth.pair)
+		pass
 
 	def net_unlock(self):
-		for veth in self._veths:
-			util.ifup(veth.pair)
-			if veth.link and not self._bridged:
-				util.bridge_add(veth.pair, veth.link)
+		pass
 
 	def can_migrate_tcp(self):
 		return True


### PR DESCRIPTION
Blocking network interfaces is non-essential for a dump, but it
blocks traffic which is crucial for a successful checkpoint of an
NFS client inside of the container.