### PR TITLE
p.haul: Introduce action scripts executed on different stages

### DIFF
--- a/phaul/criu_cr.py
+++ b/phaul/criu_cr.py
@@ -38,6 +38,7 @@ def criu_dump(htype, pid, img, criu_connection, fs):
 		elif resp.notify.script == "network-unlock":
 			htype.net_unlock()
 
+		htype.run_action_scripts(resp.notify.script)
 		logging.info("\t\tNotify (%s)", resp.notify.script)
 		resp = criu_connection.ack_notify()
 

--- a/phaul/p_haul_lxc.py
+++ b/phaul/p_haul_lxc.py
@@ -171,6 +171,9 @@ class p_haul_type(object):
 			if veth.link and not self._bridged:
 				util.bridge_add(veth.pair, veth.link)
 
+	def run_action_scripts(self, stage):
+		pass
+
 	def can_migrate_tcp(self):
 		return True
 

--- a/phaul/p_haul_pid.py
+++ b/phaul/p_haul_pid.py
@@ -106,6 +106,9 @@ class p_haul_type(object):
 	def net_unlock(self):
 		pass
 
+	def run_action_scripts(self, stage):
+		pass
+
 	def can_migrate_tcp(self):
 		return False
 


### PR DESCRIPTION
CRIU has actions scripts which are executed on different stages,
however when it is executed in RPC mode - scripts are not invoked.
This patch introduces action scripts routine in p.haul itself.
Action scripts are required to enable migration of a container with
active NFS client running inside.

Signed-off-by: Pavel Vokhmyanin <pvokhmyanin@virtuozzo.com>