### PR TITLE
p.haul: Introduce action scripts executed on different stages

### DIFF
--- a/phaul/criu_cr.py
+++ b/phaul/criu_cr.py
@@ -38,6 +38,7 @@ def criu_dump(htype, pid, img, criu_connection, fs):
 		elif resp.notify.script == "network-unlock":
 			htype.net_unlock()
 
+		htype.run_action_scripts(resp.notify.script)
 		logging.info("\t\tNotify (%s)", resp.notify.script)
 		resp = criu_connection.ack_notify()
 

--- a/phaul/p_haul_docker.py
+++ b/phaul/p_haul_docker.py
@@ -76,6 +76,9 @@ class p_haul_type(object):
 	def stop(self, umount):
 		pass
 
+	def run_action_scripts(self, stage):
+		pass
+
 	def get_fs(self, fdfs=None):
 		# use rsync for rootfs and configuration directories
 		return fs_haul_subtree.p_haul_fs(

--- a/phaul/p_haul_lxc.py
+++ b/phaul/p_haul_lxc.py
@@ -171,6 +171,9 @@ class p_haul_type(object):
 			if veth.link and not self._bridged:
 				util.bridge_add(veth.pair, veth.link)
 
+	def run_action_scripts(self, stage):
+		pass
+
 	def can_migrate_tcp(self):
 		return True
 

--- a/phaul/p_haul_pid.py
+++ b/phaul/p_haul_pid.py
@@ -106,6 +106,9 @@ class p_haul_type(object):
 	def net_unlock(self):
 		pass
 
+	def run_action_scripts(self, stage):
+		pass
+
 	def can_migrate_tcp(self):
 		return False
 

--- a/phaul/p_haul_vz.py
+++ b/phaul/p_haul_vz.py
@@ -36,6 +36,11 @@ vz_cgroup_mount_map = {
 }
 
 
+vz_action_scripts = {
+	"post-network-lock": ["/usr/libexec/criu/scripts/nfs-ports-allow.sh"],
+}
+
+
 class p_haul_type(object):
 	def __init__(self, ctid):
 		self._ctid = ctid
@@ -363,6 +368,17 @@ class p_haul_type(object):
 
 	def net_unlock(self):
 		pass
+
+	def run_action_scripts(self, stage):
+		if stage not in vz_action_scripts:
+			return
+		script_env = os.environ.copy()
+		script_env["CRTOOLS_INIT_PID"] = str(self.root_task_pid())
+		script_env["CRTOOLS_SCRIPT_ACTION"] = stage
+		for script_bin in vz_action_scripts[stage]:
+			child = subprocess.Popen(script_bin, env=script_env)
+			child.wait()
+			logging.info("\t\t\tAction script %s finished with exit code %d" % (script_bin, child.returncode))
 
 	def can_migrate_tcp(self):
 		return True


### PR DESCRIPTION
CRIU has actions scripts which are executed on different stages,
however when it is executed in RPC mode - scripts are not invoked.
This patch introduces action scripts routine in p.haul itself.
Action scripts are required to enable migration of a container with
active NFS client running inside.

Signed-off-by: Pavel Vokhmyanin <pvokhmyanin@virtuozzo.com>