### PR TITLE
p.haul: Use tcp_skip_in_flight CRIU option unconditionally

### DIFF
--- a/phaul/criu_req.py
+++ b/phaul/criu_req.py
@@ -57,6 +57,7 @@ def _make_common_dump_req(typ, pid, htype, img, connection, fs):
 
 	req.opts.images_dir_fd = img.image_dir_fd()
 	req.opts.work_dir_fd = img.work_dir_fd()
+	req.opts.tcp_skip_in_flight = img.tcp_skip_in_flight
 	req.opts.auto_dedup = img.auto_dedup
 	p_img = img.prev_image_dir()
 	if p_img:
@@ -95,6 +96,7 @@ def make_page_server_req(img, connection):
 	req.opts.images_dir_fd = img.image_dir_fd()
 	req.opts.work_dir_fd = img.work_dir_fd()
 	req.opts.auto_dedup = img.auto_dedup
+	req.opts.tcp_skip_in_flight = img.tcp_skip_in_flight
 
 	p_img = img.prev_image_dir()
 	if p_img:
@@ -118,6 +120,7 @@ def make_restore_req(htype, img, nroot):
 	req.opts.images_dir_fd = img.image_dir_fd()
 	req.opts.work_dir_fd = img.work_dir_fd()
 	req.opts.auto_dedup = img.auto_dedup
+	req.opts.tcp_skip_in_flight = img.tcp_skip_in_flight
 	req.opts.notify_scripts = True
 
 	if htype.can_migrate_tcp():

--- a/phaul/images.py
+++ b/phaul/images.py
@@ -86,6 +86,7 @@ class phaul_images(object):
 	def set_options(self, opts):
 		self.auto_dedup = opts["auto_dedup"]
 		self._keep_on_close = opts["keep_images"]
+		self.tcp_skip_in_flight = True
 
 		suf = time.strftime("-%y.%m.%d-%H.%M", time.localtime())
 		util.makedirs(opts["img_path"])


### PR DESCRIPTION
Until CRIU learns to support sockets from a listen socket queue it's
better to drop half-opened sockets - this approach does not pose any
noticeable drawback to the users and allows migration to succeed.

Signed-off-by: Pavel Vokhmyanin <pvokhmyanin@virtuozzo.com>